### PR TITLE
Adding support for macOS (fixing build errors)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,5 +19,14 @@
         'msvs_settings': {
             'VCCLCompilerTool': { 'ExceptionHandling': 1, 'AdditionalOptions': ['-std:c++17'] },
         },
+        'conditions': [
+            ['OS=="mac"', {
+                'xcode_settings': {
+                    'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+                    'MACOSX_DEPLOYMENT_TARGET': '10.14',
+                    'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',
+                }
+            }]
+        ]
     }]
 }


### PR DESCRIPTION
Hi @sjoerd108,
thank you for the effort you put in this project.
I'm currently using this library on macOS 10.15 (Catalina) and, when I first added the package to my project, the installation was failing because of build errors.

I must say I have absolutely no experience with node-gyp, cpp and pretty much anything in this repo 😅, but I could finally make it work with a few tweaks to the `binding.gyp` file.

From my understanding here is what is happening:
- exceptions are disabled by default, so `GCC_ENABLE_CPP_EXCEPTIONS` must be set manually
- the default deployment target for macOS on node-gyp is `10.13` but it seems like some of your code uses features that were introduced in version `10.14`, so I had to bump `MACOSX_DEPLOYMENT_TARGET` manually as well
- it looks like you already set the language standard to `c++17` at line 6, so I really have no clue why I had to add `CLANG_CXX_LANGUAGE_STANDARD` as well... but it doesn't work without it

I didn't have the chance to test this on any macOS version other than `10.15`, but since the deployment target is lower than the version I'm running I guess it should also work with higher versions... (A 🔮 would probably be more accurate than me here...)

I hope this can be helpful.

Thank you for your time.